### PR TITLE
Fixed Inactive ports GENG method call

### DIFF
--- a/usb/manual/ssdt.md
+++ b/usb/manual/ssdt.md
@@ -115,7 +115,7 @@ Where:
         {
             Method (_UPC, 0, NotSerialized)  // _UPC: USB Port Capabilities
             {
-                Return (GENG (Zero)) // <-- This is the modification required if you want to use the GENG method
+                Return (GENG (Zero, Zero)) // <-- This is the modification required if you want to use the GENG method
             }
 
             Method (_PLD, 0, NotSerialized)  // _PLD: Physical Location of Device


### PR DESCRIPTION
Please note that despite front-panel connectors can have different speeds (USB2 or USB3), it's preferable to define the USB2 ports as Internal (aka use `0xFF` type) while for USB3 ports you can use `0x03` type 